### PR TITLE
move from aplay to ffplay

### DIFF
--- a/fediplay.py
+++ b/fediplay.py
@@ -25,7 +25,6 @@ class Queue(object):
 
         def run_thread(filename, cb_complete):
             print('==> Playing', filename)
-            cmd = 'ffplay -v 0 -nostats -hide_banner -autoexit -nodisp'.split()
             run(['ffplay', '-v', '0', '-nostats', '-hide_banner', '-autoexit', '-nodisp', filename])
             cb_complete()
 

--- a/fediplay.py
+++ b/fediplay.py
@@ -25,7 +25,8 @@ class Queue(object):
 
         def run_thread(filename, cb_complete):
             print('==> Playing', filename)
-            run(['afplay', filename])
+            cmd = 'ffplay -v 0 -nostats -hide_banner -autoexit -nodisp'.split()
+            run(['ffplay', '-v', '0', '-nostats', '-hide_banner', '-autoexit', '-nodisp', filename])
             cb_complete()
 
         thread = Thread(target=run_thread, args=(filename, cb_complete))


### PR DESCRIPTION
here's the oh so simple change to fediplay to use ffplay instead of aplay.

tested on Windows 10 Professional under cmd.exe using python 3.6.4 and statically linked ffmpeg binaries (build 20171228-be4dfbf) from https://ffmpeg.zeranoe.com/builds/