### PR TITLE
fixes naming issue after Mastodon.py api change

### DIFF
--- a/fediplay.py
+++ b/fediplay.py
@@ -72,7 +72,7 @@ def login(api_base_url, email, password):
 def stream(api_base_url):
     client = Mastodon(client_id='clientcred.secret', access_token='usercred.secret', api_base_url=api_base_url)
     listener = StreamListener()
-    client.user_stream(listener)
+    client.stream_user(listener)
 
 def extract_tags(toot):
     return [tag['name'] for tag in toot['tags']]


### PR DESCRIPTION
Found a bug when running on Windows - "AttributeError: 'Mastodon' object has no attribute 'user_stream'". The Mastodon.py does have[ a "stream_user" function](https://github.com/halcy/Mastodon.py/blob/master/mastodon/Mastodon.py#L1361) so I assume that's the intended call. 