### PR TITLE
Add the ability to use the browser auth flow

### DIFF
--- a/fediplay.py
+++ b/fediplay.py
@@ -73,8 +73,7 @@ def register(api_base_url):
     Mastodon.create_app('fediplay', api_base_url=api_base_url, to_file='clientcred.secret')
     umask(old_umask)
 
-def login(api_base_url, grant_code):
-    client = Mastodon(client_id='clientcred.secret', api_base_url=api_base_url)
+def login(client, grant_code):
     old_umask = umask(0o77)
     client.log_in(code=grant_code, to_file='usercred.secret')
     umask(old_umask)
@@ -128,7 +127,7 @@ def main():
         print("Open this page in your browser and follow the instructions to get the code you need, then paste it here")
         print(client.auth_request_url())
         grant_code = input('Code? ')
-        login(api_base_url, grant_code)
+        login(client, grant_code)
 
     stream(api_base_url)
 

--- a/fediplay.py
+++ b/fediplay.py
@@ -73,13 +73,7 @@ def register(api_base_url):
     Mastodon.create_app('fediplay', api_base_url=api_base_url, to_file='clientcred.secret')
     umask(old_umask)
 
-def login(api_base_url, email, password):
-    client = Mastodon(client_id='clientcred.secret', api_base_url=api_base_url)
-    old_umask = umask(0o77)
-    client.log_in(email, password, to_file='usercred.secret')
-    umask(old_umask)
-
-def login_with_code(api_base_url, grant_code):
+def login(api_base_url, grant_code):
     client = Mastodon(client_id='clientcred.secret', api_base_url=api_base_url)
     old_umask = umask(0o77)
     client.log_in(code=grant_code, to_file='usercred.secret')
@@ -130,16 +124,11 @@ def main():
 
     if not path.exists('usercred.secret'):
         print('==> No usercred.secret; logging in')
-        if '-b' in argv or '--browser' in argv:
-            client = Mastodon(client_id='clientcred.secret', api_base_url=api_base_url)
-            print("Open this page in your browser and follow the instructions to get the code you need, then paste it here")
-            print(client.auth_request_url())
-            grant_code = getpass('Code? ')
-            login_with_code(api_base_url, grant_code)
-        else:
-            email = input('Email: ')
-            password = getpass('Password: ')
-            login(api_base_url, email, password)
+        client = Mastodon(client_id='clientcred.secret', api_base_url=api_base_url)
+        print("Open this page in your browser and follow the instructions to get the code you need, then paste it here")
+        print(client.auth_request_url())
+        grant_code = getpass('Code? ')
+        login(api_base_url, grant_code)
 
     stream(api_base_url)
 

--- a/fediplay.py
+++ b/fediplay.py
@@ -127,7 +127,7 @@ def main():
         client = Mastodon(client_id='clientcred.secret', api_base_url=api_base_url)
         print("Open this page in your browser and follow the instructions to get the code you need, then paste it here")
         print(client.auth_request_url())
-        grant_code = getpass('Code? ')
+        grant_code = input('Code? ')
         login(api_base_url, grant_code)
 
     stream(api_base_url)

--- a/fediplay.py
+++ b/fediplay.py
@@ -111,7 +111,7 @@ def build_play_command(filename):
 def main():
     from getpass import getpass
     from os import path
-    from sys import exit, argv
+    from sys import exit
 
     api_base_url = environ.get('FEDIPLAY_API_BASE_URL')
     if not api_base_url:


### PR DESCRIPTION
I use 2-factor auth for my account and while I know I can just turn it off, authorize the app, and turn it back on, I don't want to do that all the time. This change lets you pass `-b/--browser` to `fediplay.py` to make it use the browser to display a grant code, which the user then pastes into the terminal.