### PR TITLE
Don't try to index this list if it's empty

### DIFF
--- a/fediplay.py
+++ b/fediplay.py
@@ -66,7 +66,8 @@ class StreamListener(mastodon.StreamListener):
         tags = extract_tags(status)
         if 'fediplay' in tags:
             links = extract_links(status)
-            self.queue.add(links[0])
+            if links:
+                self.queue.add(links[0])
 
 def register(api_base_url):
     old_umask = umask(0o77)


### PR DESCRIPTION
toots with the #fediplay tag, but no links, caused fediplay to crash
with an `IndexError`